### PR TITLE
Add trending images and favorite control

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { observer } from 'mobx-react-lite';
 import { FilterControls } from '../src/components/FilterControls';
 import { ProductList } from '../src/components/ProductList';
+import { TrendingSection } from '../src/components/TrendingSection';
 import { filterStore } from '../src/stores/FilterStore';
 import { productStore } from '../src/stores/ProductStore';
 
@@ -10,6 +11,7 @@ export default observer(function HomePage() {
   return (
     <div>
       <h1>Clothing Store</h1>
+      <TrendingSection />
       <FilterControls store={filterStore} />
       <ProductList productStore={productStore} filterStore={filterStore} />
     </div>

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { productDetailStore } from '../../../src/stores/ProductDetailStore';
+import { favoriteStore } from '../../../src/stores/FavoriteStore';
+
+export default observer(function ProductDetailPage() {
+  const params = useParams();
+  const id = Number(params.id);
+
+  useEffect(() => {
+    productDetailStore.fetchProduct(id);
+    return () => productDetailStore.clear();
+  }, [id]);
+
+  if (productDetailStore.isLoading || !productDetailStore.product)
+    return <div>Loading...</div>;
+
+  const { product, shops, similar } = productDetailStore;
+
+  return (
+    <div>
+      <h1>{product!.name}</h1>
+      <button onClick={() => favoriteStore.toggle(product!.id)}>
+        {favoriteStore.isFavorite(product!.id) ? '★' : '☆'}
+      </button>
+      <img src={product!.image} alt={product!.name} width={600} height={400} />
+      <p>{product!.description}</p>
+      <h3>Available at:</h3>
+      <ul>
+        {shops.map((s, i) => (
+          <li key={i}>{s}</li>
+        ))}
+      </ul>
+      <h3>Similar Items</h3>
+      <div className="product-grid">
+        {similar.map(item => (
+          <Link href={`/product/${item.id}`} key={item.id} className="product-card">
+            <div>{item.name}</div>
+            <div>${item.price}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/src/api/fakeDb.ts
+++ b/src/api/fakeDb.ts
@@ -15,7 +15,7 @@ const products: FakeProduct[] = [];
 
 for (let i = 1; i <= 50; i++) {
   const gender = i % 3 === 0 ? 'men' : i % 3 === 1 ? 'women' : 'unisex';
-  const type = ['t-shirt', 'pants', 'dress'][i % 3];
+  const type = ['t-shirt', 'trousers', 'dress'][i % 3];
   products.push({
     id: i,
     name: `${gender} ${type} ${i}`,

--- a/src/api/fakeDb.ts
+++ b/src/api/fakeDb.ts
@@ -6,6 +6,11 @@ export interface FakeProduct {
   gender: 'men' | 'women' | 'unisex';
 }
 
+export interface FakeProductDetail extends FakeProduct {
+  description: string;
+  image: string;
+}
+
 const products: FakeProduct[] = [];
 
 for (let i = 1; i <= 50; i++) {
@@ -19,6 +24,12 @@ for (let i = 1; i <= 50; i++) {
     gender,
   });
 }
+
+const productDetails: FakeProductDetail[] = products.map(p => ({
+  ...p,
+  description: `Description for ${p.name}`,
+  image: `https://placehold.co/600x400?text=${encodeURIComponent(p.name)}`,
+}));
 
 export function fetchProducts(params: {
   page: number;
@@ -42,4 +53,26 @@ export function fetchProducts(params: {
   const data = result.slice(start, end);
   const hasMore = end < result.length;
   return Promise.resolve({ data, hasMore });
+}
+
+export function fetchTrendingProducts() {
+  return Promise.resolve(products.slice(0, 5));
+}
+
+export function fetchProductDetail(id: number) {
+  const detail = productDetails.find(p => p.id === id);
+  if (!detail) throw new Error('Product not found');
+  return Promise.resolve(detail);
+}
+
+export function fetchProductShops(id: number) {
+  const shops = ['Fashion Co', 'Style Hub', 'Clothing Store'].map(s => `${s} #${id}`);
+  return Promise.resolve(shops);
+}
+
+export function fetchSimilarProducts(id: number) {
+  const product = products.find(p => p.id === id);
+  if (!product) return Promise.resolve([]);
+  const similar = products.filter(p => p.type === product.type && p.id !== id).slice(0, 3);
+  return Promise.resolve(similar);
 }

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -33,7 +33,7 @@ export const FilterControls = observer(({ store }: Props) => {
       <select value={store.type || ''} onChange={e => store.setType(e.target.value || undefined)}>
         <option value="">All Types</option>
         <option value="t-shirt">T-Shirts</option>
-        <option value="pants">Pants</option>
+        <option value="trousers">Trousers</option>
         <option value="dress">Dresses</option>
       </select>
       <select value={store.gender || ''} onChange={e => store.setGender(e.target.value || undefined)}>

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -2,6 +2,7 @@
 
 import { observer } from 'mobx-react-lite';
 import { useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { ProductStoreType } from '../stores/ProductStore';
 import { FilterStoreType } from '../stores/FilterStore';
 import { favoriteStore } from '../stores/FavoriteStore';
@@ -34,7 +35,7 @@ export const ProductList = observer(({ productStore, filterStore }: Props) => {
       <div className="product-grid">
         {productStore.products.map(p => (
           <div key={p.id} className="product-card">
-            <div>{p.name}</div>
+            <Link href={`/product/${p.id}`}>{p.name}</Link>
             <div>${p.price}</div>
             <button onClick={() => favoriteStore.toggle(p.id)}>
               {favoriteStore.isFavorite(p.id) ? '★' : '☆'}

--- a/src/components/TrendingSection.tsx
+++ b/src/components/TrendingSection.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import Link from 'next/link';
+import { trendingStore } from '../stores/TrendingStore';
+
+export const TrendingSection = observer(() => {
+  useEffect(() => {
+    trendingStore.fetchTrending();
+  }, []);
+
+  if (!trendingStore.items.length) return null;
+
+  return (
+    <div>
+      <h2>Trending Now</h2>
+      <div className="product-grid">
+        {trendingStore.items.map(p => (
+          <Link href={`/product/${p.id}`} key={p.id} className="product-card">
+            <img
+              src="https://placehold.co/600x400"
+              alt={p.name}
+              width={200}
+              height={133}
+            />
+            <div>{p.name}</div>
+            <div>${p.price}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -9,3 +9,10 @@ export const ProductSchema = z.object({
 });
 
 export type Product = z.infer<typeof ProductSchema>;
+
+export const ProductDetailSchema = ProductSchema.extend({
+  description: z.string(),
+  image: z.string().url(),
+});
+
+export type ProductDetail = z.infer<typeof ProductDetailSchema>;

--- a/src/stores/ApiStore.ts
+++ b/src/stores/ApiStore.ts
@@ -1,6 +1,13 @@
 import axios, { AxiosAdapter, AxiosRequestConfig } from 'axios';
-import { fetchProducts } from '../api/fakeDb';
-import { Product, ProductSchema } from '../models/Product';
+import {
+  fetchProducts,
+  fetchTrendingProducts,
+  fetchProductDetail,
+  fetchProductShops,
+  fetchSimilarProducts,
+} from '../api/fakeDb';
+import { Product, ProductSchema, ProductDetailSchema } from '../models/Product';
+import { z } from 'zod';
 
 const fakeAdapter = async (config: AxiosRequestConfig) => {
   if (config.url === '/products' && config.method === 'get') {
@@ -22,6 +29,52 @@ const fakeAdapter = async (config: AxiosRequestConfig) => {
       data: result,
     };
   }
+  if (config.url === '/trending' && config.method === 'get') {
+    const data = await fetchTrendingProducts();
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  const productDetailMatch = config.url?.match(/^\/products\/(\d+)$/);
+  if (productDetailMatch && config.method === 'get') {
+    const id = Number(productDetailMatch[1]);
+    const data = await fetchProductDetail(id);
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  const shopsMatch = config.url?.match(/^\/products\/(\d+)\/shops$/);
+  if (shopsMatch && config.method === 'get') {
+    const id = Number(shopsMatch[1]);
+    const data = await fetchProductShops(id);
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  const similarMatch = config.url?.match(/^\/products\/(\d+)\/similar$/);
+  if (similarMatch && config.method === 'get') {
+    const id = Number(similarMatch[1]);
+    const data = await fetchSimilarProducts(id);
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
   return Promise.reject(new Error(`No mock for ${config.url}`));
 };
 
@@ -35,6 +88,26 @@ class ApiStore {
       hasMore: response.data.hasMore as boolean,
     };
     return result;
+  }
+
+  async getTrendingProducts(): Promise<Product[]> {
+    const response = await this.axios.get('/trending');
+    return (response.data as unknown[]).map(item => ProductSchema.parse(item));
+  }
+
+  async getProductDetail(id: number): Promise<z.infer<typeof ProductDetailSchema>> {
+    const response = await this.axios.get(`/products/${id}`);
+    return ProductDetailSchema.parse(response.data);
+  }
+
+  async getProductShops(id: number): Promise<string[]> {
+    const response = await this.axios.get(`/products/${id}/shops`);
+    return response.data as string[];
+  }
+
+  async getSimilarProducts(id: number): Promise<Product[]> {
+    const response = await this.axios.get(`/products/${id}/similar`);
+    return (response.data as unknown[]).map(item => ProductSchema.parse(item));
   }
 }
 

--- a/src/stores/ProductDetailStore.ts
+++ b/src/stores/ProductDetailStore.ts
@@ -1,0 +1,47 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import { Product, ProductDetail } from '../models/Product';
+import { apiStore } from './ApiStore';
+
+
+class ProductDetailStore {
+  product: ProductDetail | null = null;
+  shops: string[] = [];
+  similar: Product[] = [];
+  isLoading = false;
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  async fetchProduct(id: number) {
+    this.isLoading = true;
+    try {
+      const [detail, shops, similar] = await Promise.all([
+        apiStore.getProductDetail(id),
+        apiStore.getProductShops(id),
+        apiStore.getSimilarProducts(id),
+      ]);
+      runInAction(() => {
+        this.product = detail;
+        this.shops = shops;
+        this.similar = similar;
+      });
+    } catch (e) {
+      console.error('Failed to fetch product detail', e);
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+
+  clear() {
+    this.product = null;
+    this.shops = [];
+    this.similar = [];
+    this.isLoading = false;
+  }
+}
+
+export const productDetailStore = new ProductDetailStore();
+export type ProductDetailStoreType = ProductDetailStore;

--- a/src/stores/TrendingStore.ts
+++ b/src/stores/TrendingStore.ts
@@ -1,0 +1,32 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import { Product } from '../models/Product';
+import { apiStore } from './ApiStore';
+
+class TrendingStore {
+  items: Product[] = [];
+  isLoading = false;
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  async fetchTrending() {
+    if (this.items.length || this.isLoading) return;
+    this.isLoading = true;
+    try {
+      const data = await apiStore.getTrendingProducts();
+      runInAction(() => {
+        this.items = data;
+      });
+    } catch (e) {
+      console.error('Failed to fetch trending products', e);
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+}
+
+export const trendingStore = new TrendingStore();
+export type TrendingStoreType = TrendingStore;


### PR DESCRIPTION
## Summary
- show placeholder images in the trending section
- fetch item images from `placehold.co` in the fake API
- allow adding an item to favorites on its detail page
- set fixed sizes on images so layout doesn't jump while loading
- link products in the main list to their detail pages
- validate product detail data with Zod and reset loading state in the detail store

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6865918b264483228e350ad4262ad556