### PR TITLE
Use fake API for favorites

### DIFF
--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -13,6 +13,7 @@ export default observer(function ProductDetailPage() {
 
   useEffect(() => {
     productDetailStore.fetchProduct(id);
+    favoriteStore.fetchFavorites();
     return () => productDetailStore.clear();
   }, [id]);
 

--- a/src/api/fakeDb.ts
+++ b/src/api/fakeDb.ts
@@ -76,3 +76,20 @@ export function fetchSimilarProducts(id: number) {
   const similar = products.filter(p => p.type === product.type && p.id !== id).slice(0, 3);
   return Promise.resolve(similar);
 }
+
+// --- favorites API ---
+const favorites = new Set<number>();
+
+export function fetchFavorites() {
+  return Promise.resolve(Array.from(favorites));
+}
+
+export function addFavorite(id: number) {
+  favorites.add(id);
+  return Promise.resolve(Array.from(favorites));
+}
+
+export function removeFavorite(id: number) {
+  favorites.delete(id);
+  return Promise.resolve(Array.from(favorites));
+}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -21,6 +21,10 @@ export const ProductList = observer(({ productStore, filterStore }: Props) => {
   }, [filterStore.gender, filterStore.type, filterStore.search, filterStore.minPrice, filterStore.maxPrice]);
 
   useEffect(() => {
+    favoriteStore.fetchFavorites();
+  }, []);
+
+  useEffect(() => {
     const ob = new IntersectionObserver(entries => {
       if (entries[0].isIntersecting) {
         productStore.fetchNextPage(filterStore);

--- a/src/stores/ApiStore.ts
+++ b/src/stores/ApiStore.ts
@@ -5,6 +5,9 @@ import {
   fetchProductDetail,
   fetchProductShops,
   fetchSimilarProducts,
+  fetchFavorites,
+  addFavorite,
+  removeFavorite,
 } from '../api/fakeDb';
 import { Product, ProductSchema, ProductDetailSchema } from '../models/Product';
 import { z } from 'zod';
@@ -31,6 +34,39 @@ const fakeAdapter = async (config: AxiosRequestConfig) => {
   }
   if (config.url === '/trending' && config.method === 'get') {
     const data = await fetchTrendingProducts();
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  if (config.url === '/favorites' && config.method === 'get') {
+    const data = await fetchFavorites();
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  const favoriteMatch = config.url?.match(/^\/favorites\/(\d+)$/);
+  if (favoriteMatch && config.method === 'post') {
+    const id = Number(favoriteMatch[1]);
+    const data = await addFavorite(id);
+    return {
+      config,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data,
+    };
+  }
+  if (favoriteMatch && config.method === 'delete') {
+    const id = Number(favoriteMatch[1]);
+    const data = await removeFavorite(id);
     return {
       config,
       status: 200,
@@ -108,6 +144,21 @@ class ApiStore {
   async getSimilarProducts(id: number): Promise<Product[]> {
     const response = await this.axios.get(`/products/${id}/similar`);
     return (response.data as unknown[]).map(item => ProductSchema.parse(item));
+  }
+
+  async getFavorites(): Promise<number[]> {
+    const response = await this.axios.get('/favorites');
+    return response.data as number[];
+  }
+
+  async addFavorite(id: number): Promise<number[]> {
+    const response = await this.axios.post(`/favorites/${id}`);
+    return response.data as number[];
+  }
+
+  async removeFavorite(id: number): Promise<number[]> {
+    const response = await this.axios.delete(`/favorites/${id}`);
+    return response.data as number[];
   }
 }
 

--- a/src/stores/FavoriteStore.ts
+++ b/src/stores/FavoriteStore.ts
@@ -1,15 +1,48 @@
-import { makeAutoObservable } from 'mobx';
+import { makeAutoObservable, runInAction } from 'mobx';
+import { apiStore } from './ApiStore';
 
 class FavoriteStore {
   favorites = new Set<number>();
+  isLoading = false;
 
   constructor() {
     makeAutoObservable(this);
   }
 
-  toggle(id: number) {
-    if (this.favorites.has(id)) this.favorites.delete(id);
-    else this.favorites.add(id);
+  async fetchFavorites() {
+    if (this.isLoading) return;
+    this.isLoading = true;
+    try {
+      const data = await apiStore.getFavorites();
+      runInAction(() => {
+        this.favorites = new Set(data);
+      });
+    } catch (e) {
+      console.error('Failed to fetch favorites', e);
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+
+  async toggle(id: number) {
+    if (this.isLoading) return;
+    this.isLoading = true;
+    try {
+      let data: number[];
+      if (this.favorites.has(id)) data = await apiStore.removeFavorite(id);
+      else data = await apiStore.addFavorite(id);
+      runInAction(() => {
+        this.favorites = new Set(data);
+      });
+    } catch (e) {
+      console.error('Failed to update favorites', e);
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
   }
 
   isFavorite(id: number) {


### PR DESCRIPTION
## Summary
- implement fake API endpoints for favorites
- extend ApiStore with favorite actions
- fetch favorites in MobX store and components

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b685b93a083229793fc0f8a6a5049